### PR TITLE
Add revalidate export for caching

### DIFF
--- a/src/app/(pages)/posts/[id]/page.tsx
+++ b/src/app/(pages)/posts/[id]/page.tsx
@@ -7,6 +7,9 @@ import Container from '@/components/container';
 import { serialize } from '@/components/slate/utils/helpers';
 import styles from './page.module.scss';
 
+// Revalidate every hour
+export const revalidate = 3600;
+
 async function getData(id: string): Promise<Post | null> {
   const post = await getPost(id);
 

--- a/src/app/(pages)/posts/page.tsx
+++ b/src/app/(pages)/posts/page.tsx
@@ -3,6 +3,9 @@ import Container from '@/components/container';
 import Result from '@/components/post/result';
 import styles from './page.module.scss';
 
+// Revalidate every hour
+export const revalidate = 3600;
+
 async function getData() {
   const posts = await getPosts();
 

--- a/src/app/(pages)/tags/[slug]/page.tsx
+++ b/src/app/(pages)/tags/[slug]/page.tsx
@@ -3,6 +3,9 @@ import Result from '@/components/post/result';
 import { getTagBySlug } from '@/controllers/tagController';
 import styles from './page.module.scss'
 
+// Revalidate every hour
+export const revalidate = 3600;
+
 async function getData(slug: string) {
   const tag = await getTagBySlug(slug);
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,9 @@ import Featured from '@/components/post/featured';
 import { getFeaturedPost, getLatestPost } from '@/utils/functions';
 import styles from './page.module.scss';
 
+// Revalidate every hour
+export const revalidate = 3600;
+
 async function getData() {
   const posts = await getPosts();
   const tags = await getTags();


### PR DESCRIPTION
Each page using cached data now exports a revalidate tag. Cache should need refresh every hour. 