### PR TITLE
Fix image pathing

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,3 +3,5 @@
 ## 1.0.1
 
 - Fixed cache revalidation issue. Cache data for Posts and Tags should now revalidate every hour.
+- Fixed an issue related to image pathing in a production environment.
+- Updated the getImageUrl function return for production builds.

--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -47,7 +47,7 @@ export function getImageUrl(key: string) {
   if (process.env.NODE_ENV === 'development') {
     return `https://${process.env.AWS_BUCKET}.s3.${process.env.AWS_REGION}.amazonaws.com/${key}`;
   } else {
-    return `https://blog.jordantate.dev/${key}`;
+    return `/${key}`;
   }
 }
 


### PR DESCRIPTION
Updated the `getImageUrl` return to be a local path. I'm hoping that this will be handled by the nginx reverse proxy, but I currently can't test this without pushing to main. 