### PR TITLE
Revert relative URLs for post images back to absolute

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -12,8 +12,8 @@ const nextConfig = {
         protocol: 'https',
         hostname:
           process.env.NODE_ENV == 'development'
-            ? 'jt-blog.s3.eu-west-2.amazonaws.com'
-            : 'blog.jordantate.dev',
+            ? `${process.env.AWS_BUCKET}.s3.${process.env.AWS_REGION}.amazonaws.com`
+            : `${process.env.PRODUCTION_DOMAIN}`,
         port: '',
         pathname: '/images/**',
       },

--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -47,7 +47,7 @@ export function getImageUrl(key: string) {
   if (process.env.NODE_ENV === 'development') {
     return `https://${process.env.AWS_BUCKET}.s3.${process.env.AWS_REGION}.amazonaws.com/${key}`;
   } else {
-    return `/${key}`;
+    return `${process.env.PRODUCTION_URL}/${key}`;
   }
 }
 


### PR DESCRIPTION
Revert previous changes that converted URLs to relative. This did not fix the error. 